### PR TITLE
Fix link-directory theme reference

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ url: "https://monashlinks.github.io" # the base hostname & protocol for your sit
 exclude: ['README.md', 'CONTRIBUTING.md', 'Gemfile.lock', 'Gemfile']
 
 # link-directory theme config
-remote_theme: evilgoldfish/link-directory
+remote_theme: epetousis/link-directory
 real_name: Monash University
 real_home: "https://www.monash.edu/"
 source_url: "https://github.com/monashlinks/monashlinks.github.io"


### PR DESCRIPTION
Hi,

I recently updated my username and noticed this site is still referencing my old one. You should update the theme reference to make sure the theme is still able to be pulled and updated.